### PR TITLE
Replace actions/docker with "raw" actions run

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,11 +8,7 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Build
-      uses: actions/docker/cli@master
-      with:
-        args: build -t reload/lumturio-jira:test .
+      run: docker build -t reload/lumturio-jira:test .
     - name: Test
-      uses: actions/docker/cli@master
-      with:
-        args: run --rm reload/lumturio-jira:test php /opt/lumturio-jira/lumturio-jira.phar
+      run: docker run --rm reload/lumturio-jira:test php /opt/lumturio-jira/lumturio-jira.phar
           --no-interaction --version


### PR DESCRIPTION
[The action has been deprecated and is no longer available](https://github.community/t5/GitHub-Actions/Docker-action-deprecated-and-archived/td-p/33219). Replace it with the Docker installation already available.