### PR TITLE
Rename tag from SSLA to SLA

### DIFF
--- a/src/LumturioSite.php
+++ b/src/LumturioSite.php
@@ -44,7 +44,7 @@ class LumturioSite
     public function hasSecuritySLA() : bool
     {
         foreach ($this->getInfoTags() as $tag) {
-            if ('SSLA' == $tag) {
+            if ('SLA' == $tag) {
                 return true;
             }
         }


### PR DESCRIPTION
We no longer distinguish between a security SLA (SSLA) and a regular SLA.